### PR TITLE
Spotify Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,30 @@
 
 ### Production setup
 
-Set the following environment variables accordingly:
-* `DB_USER`
-* `DB_PASS`
-* `DB_HOST`
-* `DB_PORT`
-* `DB_DBNAME`
-* `DB_PREFIX`
+#### Database Setup
+Set the following environment variables accordingly (or add to `app/.env`):
+* `DB_USER` - MySQL username
+* `DB_PASS` - MySQL password
+* `DB_HOST` - MySQL server hostname
+* `DB_PORT` - MySQL server port
+* `DB_DBNAME` - MySQL database
+* `DB_PREFIX` - URI scheme to use for connecting to the db. (Defaults to `mysql+pymysql://`)
 
 Alternatively, you can set `DATABASE_URL` to specify the full URL. (Used for Heroku)
+
+#### Spotify Setup
+Set the following environment variables accordingly (or add to `app/.env`):
+
+* `SPOTIFY_CLIENT_ID`
+* `SPOTIFY_CLIENT_SECRET`
+
+You can obtain a `CLIENT_ID` and `CLIENT_SECRET` [here](https://developer.spotify.com/my-applications/#!/applications).
+Use `http://SERVER_HOST:PORT/spotify/callback` as the `Redirect URI` when setting up the app.
+
+#### Misc
+
+* `SERVER_HOST` - Defaults to `localhost`. Used to construct Spotify callback URL.
+* `PORT` - Defaults to `5000`. Flask server port. Used to construct Spotify callback URL.
 
 ## Run the app
 

--- a/app/.env.template
+++ b/app/.env.template
@@ -4,3 +4,9 @@ DB_HOST=localhost
 DB_PORT=3306
 DB_DBNAME=DropMuse
 DB_PREFIX=mysql+pymysql://
+
+SPOTIFY_CLIENT_ID=changme
+SPOTIFY_CLIENT_SECRET=changeme
+
+SERVER_HOST=localhost
+PORT=5000

--- a/app/application.py
+++ b/app/application.py
@@ -3,15 +3,18 @@ from flask import (Flask, render_template, redirect, url_for, flash, request,
 from flask_login import LoginManager, login_user, current_user, logout_user
 from flask_security import login_required
 from sqlalchemy import create_engine, text
-from settings import DB_URL, SECRET_KEY
+from settings import DB_URL, SECRET_KEY, SERVER_NAME
 from forms import RegistrationForm, LoginForm, PlaylistCreateForm
 from flask_paginate import Pagination
 import db_utils
 import utils
+from .spotify import spotify_blueprint
 
 app = Flask(__name__)
 app.secret_key = SECRET_KEY
 app.config['TEMPLATES_AUTO_RELOAD'] = True
+app.config['SERVER_NAME'] = SERVER_NAME
+app.register_blueprint(spotify_blueprint, url_prefix='/spotify')
 
 login_manager = LoginManager()
 login_manager.init_app(app)

--- a/app/db_utils.py
+++ b/app/db_utils.py
@@ -174,3 +174,21 @@ def spotify_credentials_upsert(engine, user_id, token_info):
                autocommit=True)
     with engine.connect() as con:
         con.execute(sql, user_id=user_id, token_info=json.dumps(token_info))
+
+
+def spotify_creds_for_user(engine, user_id):
+    sql = text('SELECT token_info '
+               'FROM spotify_credentials '
+               'WHERE user_id=:user_id;')
+    with engine.connect() as con:
+        res = con.execute(sql, user_id=user_id).first()
+        if res:
+            return json.loads(res[0])
+
+
+def spotify_creds_delete(engine, user_id):
+    sql = text('DELETE FROM spotify_credentials '
+               'WHERE user_id=:user_id;',
+               autocommit=True)
+    with engine.connect() as con:
+        con.execute(sql, user_id=user_id)

--- a/app/db_utils.py
+++ b/app/db_utils.py
@@ -1,6 +1,7 @@
 from werkzeug.security import (generate_password_hash, check_password_hash)
 from sqlalchemy import text
 from models import User, Playlist
+import json
 
 
 def user_exists(engine, user):
@@ -164,3 +165,12 @@ def song_by_id(engine, song_id):
                'WHERE id=:song_id')
     with engine.connect() as con:
         return con.execute(sql, song_id=song_id).fetchone()
+
+
+def spotify_credentials_upsert(engine, user_id, token_info):
+    sql = text('INSERT INTO spotify_credentials(user_id, token_info) '
+               'VALUES (:user_id, :token_info) '
+               'ON DUPLICATE KEY UPDATE token_info=:token_info;',
+               autocommit=True)
+    with engine.connect() as con:
+        con.execute(sql, user_id=user_id, token_info=json.dumps(token_info))

--- a/app/settings.py
+++ b/app/settings.py
@@ -5,13 +5,21 @@ from dotenv import load_dotenv
 dotenv_path = join(dirname(__file__), '.env')
 load_dotenv(dotenv_path)
 
+''' Generic Settings '''
+port = os.environ.get('PORT', 5000)
+server_host = os.environ.get('SERVER_HOST', 'localhost')
+SERVER_NAME = '{}:{}'.format(server_host, port)
+SECRET_KEY = os.environ.get('SECRET_KEY', 'CHANGEME')
+
+
+''' Database Settings '''
+
 DB_USER = os.environ.get('DB_USER')
 DB_PASS = os.environ.get('DB_PASS')
 DB_HOST = os.environ.get('DB_HOST')
 DB_PORT = os.environ.get('DB_PORT', 3306)
 DB_DBNAME = os.environ.get('DB_DBNAME', 'DropMuse')
 DB_PREFIX = os.environ.get('DB_PREFIX', 'mysql+pymysql://')
-SECRET_KEY = os.environ.get('SECRET_KEY', 'CHANGEME')
 
 conn_str = "{}{}:{}@{}:{}/{}".format(DB_PREFIX,
                                      DB_USER,
@@ -27,3 +35,9 @@ DB_URL = os.environ.get('CLEARDB_DATABASE_URL', DB_URL)
 # Force use of pymysql driver
 if DB_URL.startswith('mysql://'):
     DB_URL = 'mysql+pymysql' + DB_URL[5:]
+
+
+''' Spotify Settings '''
+
+SPOTIFY_CLIENT_ID = os.environ.get('SPOTIFY_CLIENT_ID')
+SPOTIFY_CLIENT_SECRET = os.environ.get('SPOTIFY_CLIENT_SECRET')

--- a/app/spotify.py
+++ b/app/spotify.py
@@ -5,20 +5,21 @@ from flask_login import current_user
 from flask_security import login_required
 from spotipy import oauth2
 import db_utils
-import app
+import application as app
 
 spotify_blueprint = Blueprint('spotify', __name__, template_folder='templates')
 SCOPE = ""
+
+redirect_uri = 'http://' + SERVER_NAME + '/spotify/callback'
+sp_oauth = oauth2.SpotifyOAuth(SPOTIFY_CLIENT_ID,
+                               SPOTIFY_CLIENT_SECRET,
+                               redirect_uri,
+                               scope=SCOPE)
 
 
 @spotify_blueprint.route('/authenticate')
 @login_required
 def start_authentication():
-    redirect_uri = 'http://' + SERVER_NAME + url_for('.auth_callback')
-    sp_oauth = oauth2.SpotifyOAuth(SPOTIFY_CLIENT_ID,
-                                   SPOTIFY_CLIENT_SECRET,
-                                   redirect_uri,
-                                   scope=SCOPE)
     auth_url = sp_oauth.get_authorize_url()
     return redirect(auth_url)
 
@@ -26,14 +27,17 @@ def start_authentication():
 @spotify_blueprint.route('/callback')
 @login_required
 def auth_callback():
-    redirect_uri = 'http://' + SERVER_NAME + url_for('.auth_callback')
-    sp_oauth = oauth2.SpotifyOAuth(SPOTIFY_CLIENT_ID,
-                                   SPOTIFY_CLIENT_SECRET,
-                                   redirect_uri,
-                                   scope=SCOPE)
     code = request.args.get('code')
     token_info = sp_oauth.get_access_token(code)
     db_utils.spotify_credentials_upsert(app.engine,
                                         current_user.id,
                                         token_info)
+    return redirect(url_for('profile', username=current_user.username))
+
+
+@spotify_blueprint.route('/disconnect')
+@login_required
+def disconnect():
+    db_utils.spotify_creds_delete(app.engine, current_user.id)
+    current_user._spotify = None
     return redirect(url_for('profile', username=current_user.username))

--- a/app/spotify.py
+++ b/app/spotify.py
@@ -1,0 +1,39 @@
+from flask import Blueprint, redirect, url_for, request
+from settings import (SPOTIFY_CLIENT_ID, SPOTIFY_CLIENT_SECRET, SERVER_NAME)
+# import spotipy
+from flask_login import current_user
+from flask_security import login_required
+from spotipy import oauth2
+import db_utils
+import app
+
+spotify_blueprint = Blueprint('spotify', __name__, template_folder='templates')
+SCOPE = ""
+
+
+@spotify_blueprint.route('/authenticate')
+@login_required
+def start_authentication():
+    redirect_uri = 'http://' + SERVER_NAME + url_for('.auth_callback')
+    sp_oauth = oauth2.SpotifyOAuth(SPOTIFY_CLIENT_ID,
+                                   SPOTIFY_CLIENT_SECRET,
+                                   redirect_uri,
+                                   scope=SCOPE)
+    auth_url = sp_oauth.get_authorize_url()
+    return redirect(auth_url)
+
+
+@spotify_blueprint.route('/callback')
+@login_required
+def auth_callback():
+    redirect_uri = 'http://' + SERVER_NAME + url_for('.auth_callback')
+    sp_oauth = oauth2.SpotifyOAuth(SPOTIFY_CLIENT_ID,
+                                   SPOTIFY_CLIENT_SECRET,
+                                   redirect_uri,
+                                   scope=SCOPE)
+    code = request.args.get('code')
+    token_info = sp_oauth.get_access_token(code)
+    db_utils.spotify_credentials_upsert(app.engine,
+                                        current_user.id,
+                                        token_info)
+    return redirect(url_for('profile', username=current_user.username))

--- a/app/spotify.py
+++ b/app/spotify.py
@@ -8,7 +8,10 @@ import db_utils
 import application as app
 
 spotify_blueprint = Blueprint('spotify', __name__, template_folder='templates')
-SCOPE = ""
+SCOPE = ' '.join(["playlist-read-private",
+                  "playlist-modify-public",
+                  "playlist-modify-private",
+                  "user-library-read"])
 
 redirect_uri = 'http://' + SERVER_NAME + '/spotify/callback'
 sp_oauth = oauth2.SpotifyOAuth(SPOTIFY_CLIENT_ID,

--- a/app/templates/layout.html
+++ b/app/templates/layout.html
@@ -12,6 +12,9 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
+    <!-- FontAwesome -->
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+
     <!-- Custom CSS -->
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='main.css') }}">
 

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -4,7 +4,12 @@
 <hr>
 {% if playlists|length > 0 %}
 <a href="{{url_for('playlist_create')}}" class="btn btn-default">New Playlist <span class="glyphicon glyphicon-plus-sign"></span></a>
-</div>
+<!-- Connect to Spotify links -->
+{% if user.spotify %}
+<a href="{{url_for('spotify.disconnect')}}" class="btn btn-default">Disconnect Spotify Account <i class="fa fa-spotify"></i></a>
+{% else %}
+<a href="{{url_for('spotify.start_authentication')}}" class="btn btn-default">Connect to Spotify <i class="fa fa-spotify"></i></a>
+{% endif %}
 <hr>
 <h4>Playlists</h4>
 <table class="table" id="playlist-table" width="100%" cellspacing="0">

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ flask-paginate==0.4.5
 Flask-Principal==0.4.0
 Flask-Security==1.7.5
 Flask-WTF==0.14.2
+honcho==0.7.1
 idna==2.2
 ipaddress==1.0.18
 itsdangerous==0.24
@@ -32,6 +33,7 @@ python-dotenv==0.6.3
 PyYAML==3.12
 requests==2.13.0
 six==1.10.0
+spotipy==2.4.4
 SQLAlchemy==1.1.6
 Werkzeug==0.11.15
 WTForms==2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ python-dotenv==0.6.3
 PyYAML==3.12
 requests==2.13.0
 six==1.10.0
-spotipy==2.4.4
+git+https://github.com/plamere/spotipy.git@7499d8e511ce3f5588a16702c9533233ec716cab
 SQLAlchemy==1.1.6
 Werkzeug==0.11.15
 WTForms==2.1

--- a/run.py
+++ b/run.py
@@ -1,6 +1,3 @@
 #!flask/bin/python
 from app.application import app
-import os
-
-PORT = int(os.environ.get('PORT', 5000))
-app.run(debug=True, host='0.0.0.0', port=PORT)
+app.run(debug=True, host='0.0.0.0')

--- a/tables.sql
+++ b/tables.sql
@@ -8,6 +8,13 @@ CREATE TABLE IF NOT EXISTS users(
     UNIQUE (email)
 );
 
+CREATE TABLE IF NOT EXISTS spotify_credentials(
+    user_id BIGINT UNSIGNED,
+    token_info TEXT,
+    FOREIGN KEY (user_id) REFERENCES users(id),
+    PRIMARY KEY (user_id)
+);
+
 CREATE TABLE IF NOT EXISTS playlists(
     id SERIAL,
     user_id BIGINT UNSIGNED NOT NULL,


### PR DESCRIPTION
* Allows users to connect their Spotify accounts to Dropmuse
* User spotify credentials stored in new `spotify_credentials` table
* A [spotipy](https://spotipy.readthedocs.io/en/latest) API object for each user is available at `current_user.spotify`. (Will be `None` if the user hasn't connected their account to Spotify)